### PR TITLE
fix: corrige edicion de documentos y aparecen profesionales selccionados

### DIFF
--- a/cocemfe_sevilla/documents/templates/update_pdf.html
+++ b/cocemfe_sevilla/documents/templates/update_pdf.html
@@ -131,7 +131,7 @@
                                 <label for="id_name" class="form-control-label px-3" style="font-family: 'Arial', sans-serif; font-weight: bold;">
                                     <i class="far fa-calendar-alt"></i> Inicio de aportaciones
                                 </label>
-                                {{ form.suggestion_start_date }}
+                                <input type="date" name="suggestion_start_date" value="{{ document.suggestion_start_date|date:'Y-m-d' }}">
                                 {% for error in form.suggestion_start_date.errors %}
                                     <span class="error text-danger">{{ error }}</span>
                                 {% endfor %}
@@ -140,7 +140,7 @@
                                 <label for="id_name" class="form-control-label px-3" style="font-family: 'Arial', sans-serif; font-weight: bold;">
                                     <i class="far fa-calendar-alt"></i> Cierre de aportaciones
                                 </label>
-                                {{ form.suggestion_end_date }}
+                                <input type="date" name="suggestion_end_date" value="{{ document.suggestion_end_date|date:'Y-m-d' }}">
                                 {% for error in form.suggestion_end_date.errors %}
                                     <span class="error text-danger">{{ error }}</span>
                                 {% endfor %}
@@ -149,7 +149,7 @@
                                 <label for="id_name" class="form-control-label px-3" style="font-family: 'Arial', sans-serif; font-weight: bold;">
                                     <i class="far fa-calendar-alt"></i> Cierre de votaciones
                                 </label>
-                                {{ form.voting_end_date }}
+                                <input type="date" name="voting_end_date" value="{{ document.voting_end_date|date:'Y-m-d' }}">
                                 {% for error in form.voting_end_date.errors %}
                                     <span class="error text-danger">{{ error }}</span>
                                 {% endfor %}
@@ -184,7 +184,7 @@
                                 </label>
                                 {% for professional in form.professionals.field.queryset %}
                                     {% if professional in professionals_not_superuser %}
-                                        <input type="checkbox" id="id_professional_{{ professional.id }}" name="professionals" value="{{ professional.id }}">
+                                        <input type="checkbox" id="id_professional_{{ professional.id }}" name="professionals" value="{{ professional.id }}" {% if professional in document.professionals.all %}checked{% endif %}>
                                         <label for="id_professional_{{ professional.id }}">{{ professional.username }}</label><br>
                                     {% endif %}
                                 {% endfor %}

--- a/cocemfe_sevilla/documents/views.py
+++ b/cocemfe_sevilla/documents/views.py
@@ -42,7 +42,7 @@ def upload_pdf(request):
                     # Renderizar el mensaje de correo electrónico desde un template
                     message = render_to_string('email/new_document_notification.txt', {'document': document, 'professional': professional})
                     send_mail(subject, message, from_email, [professional.email], fail_silently=False)
-                return redirect('list_pdf')
+                return redirect('view_pdf_admin', document.id)
         else:
             form = PDFUploadForm()
         return render(request, 'upload_pdf.html', {'form': form, 'professionals_not_superuser': professionals})
@@ -93,7 +93,7 @@ def view_pdf_admin(request, pk):
         return render(request, '403.html')
     
 @login_required
-def update_pdf(request,pk):
+def update_pdf(request, pk):
     document = get_object_or_404(Document, pk=pk)
     professionals_not_superuser = Professional.objects.filter(is_superuser=False)
     if request.user.is_superuser:
@@ -117,8 +117,9 @@ def update_pdf(request,pk):
                 updated_document.save()
                 form.save_m2m() 
                 
-                return redirect('list_pdf')
+                return redirect('view_pdf_admin', updated_document.id)
         else:
+            # Aquí pasamos la instancia del documento para que el formulario se inicialice con los datos del documento.
             form = PDFUploadForm(instance=document)
         return render(request, 'update_pdf.html', {'form': form, 'document': document, 'professionals_not_superuser': professionals_not_superuser})
     else:


### PR DESCRIPTION
Cuando se edita un documento, los profesionales se mantienen seleccionados en caso de estar previamente seleccionados. Las fechas también se quedan definidas en caso de estar previamente definidas.

closes #198 