### PR TITLE
feat: Implementadas pantallas de error #Closes #322

### DIFF
--- a/cocemfe_sevilla/base/templates/404.html
+++ b/cocemfe_sevilla/base/templates/404.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+
+{% block title %}Error 404 - Página no encontrada{% endblock %}
+
+{% block contenido %}
+<div class="container text-center mt-4">
+    <h1 class="mt-4">[Error 404] - Página no encontrada</h1>
+    <p class="mt-4">La página que estás buscando no pudo ser encontrada.</p>
+    <a href="/" class="btn btn-primary text-white">Volver a la página de inicio</a>
+</div>
+{% endblock %}

--- a/cocemfe_sevilla/base/templates/500.html
+++ b/cocemfe_sevilla/base/templates/500.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+
+{% block title %}Error 500 - Error interno del servidor{% endblock %}
+
+{% block contenido %}
+<div class="container text-center mt-4">
+    <h1 class="mt-4">[Error 500] - Error interno del servidor</h1>
+    <p class="mt-4">Algo salió mal en el servidor. Por favor, inténtalo de nuevo más tarde.</p>
+    <a href="/" class="btn btn-primary text-white mt-4">Volver a la página de inicio</a>
+</div>
+{% endblock %}

--- a/cocemfe_sevilla/base/views.py
+++ b/cocemfe_sevilla/base/views.py
@@ -31,3 +31,9 @@ def politica_terminos(request):
         form = AceptarTerminosForm()
     
     return render(request, 'politica_terminos.html', {'form': form})
+
+def error_404(request, exception):
+    return render(request, '404.html', status=404)
+
+def error_500(request):
+    return render(request, '500.html', status=500)

--- a/cocemfe_sevilla/cocemfe_sevilla/settings.py
+++ b/cocemfe_sevilla/cocemfe_sevilla/settings.py
@@ -25,9 +25,9 @@ STATIC_DIR = Path(BASE_DIR) / 'static'
 SECRET_KEY = "django-insecure-@4zj0j16-pk64hd61$o0tz6r6)gs%%4@^780#ar-ij&qrf22_s"
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = False
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ["*"]
 
 EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 EMAIL_HOST = 'smtp.gmail.com'
@@ -159,4 +159,3 @@ CHANNEL_LAYERS = {
         "BACKEND": "channels.layers.InMemoryChannelLayer"
     }
 }
-

--- a/cocemfe_sevilla/cocemfe_sevilla/urls.py
+++ b/cocemfe_sevilla/cocemfe_sevilla/urls.py
@@ -20,6 +20,7 @@ from documents import views as docsViews
 from django.conf import settings
 from django.conf.urls.static import static
 from professionals import views as profViews
+from base import views as baseViews
 
 urlpatterns = [
     path("admin/", admin.site.urls),
@@ -38,3 +39,11 @@ urlpatterns = [
 ]
 if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+
+handler404 = 'base.views.error_404'
+handler500 = 'base.views.error_500'
+
+urlpatterns += [
+    path('error/404/', baseViews.error_404, name='error_404'),
+    path('error/500/', baseViews.error_500, name='error_500'),
+]


### PR DESCRIPTION
Se ha implementado las pantallas de error 404 y 500.

Para poder comprobar el funcionamiento, en settings.py debug se ha puesto a False:
![imagen](https://github.com/ISPP-Grupo-10/cocemfe-sevilla/assets/113366030/3943aa2a-7436-414a-9fcc-0e96a9ae0111)
Para poder ver las pantallas en acción, se puede o causar el error o ir a la ruta error/[numero error]