### PR TITLE
fix: añade django-q para actualizar los estados automaticamente

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN python manage.py makemigrations --noinput
 RUN python manage.py migrate
 RUN python fixtures/jsonmerge.py
 RUN python manage.py loaddata fixtures/data.json
-
+RUN python manage.py qcluster
 
 EXPOSE 8000
 CMD ["python", "manage.py", "runserver","0.0.0.0:8000"]

--- a/cocemfe_sevilla/cocemfe_sevilla/settings.py
+++ b/cocemfe_sevilla/cocemfe_sevilla/settings.py
@@ -59,9 +59,19 @@ INSTALLED_APPS = [
     "calendars",
     "bootstrap5",
     "base",
+    'django_q',
 
 ]
 X_FRAME_OPTIONS = 'SAMEORIGIN'
+
+Q_CLUSTER = {
+    'name': 'DjangORM',
+    'workers': 4,
+    'recycle': 500,
+    'timeout': 60,
+    'django_redis': 'default',
+    'orm': 'default'
+}
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",

--- a/cocemfe_sevilla/documents/apps.py
+++ b/cocemfe_sevilla/documents/apps.py
@@ -1,9 +1,10 @@
 from django.apps import AppConfig
-
+import sys
 
 class DocumentsConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'documents'
 
     def ready(self):
-        import documents.tasks  # Importa el archivo tasks.py
+        if 'migrate' not in sys.argv and 'makemigrations' not in sys.argv:
+            import documents.tasks

--- a/cocemfe_sevilla/documents/apps.py
+++ b/cocemfe_sevilla/documents/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class DocumentsConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'documents'
+
+    def ready(self):
+        import documents.tasks  # Importa el archivo tasks.py

--- a/cocemfe_sevilla/documents/tasks.py
+++ b/cocemfe_sevilla/documents/tasks.py
@@ -1,0 +1,36 @@
+from django.utils import timezone
+from django_q.tasks import schedule
+from django_q.models import Schedule
+
+from .models import Document
+
+def update_document_status():
+    documents = Document.objects.filter(
+        status='Borrador',
+        suggestion_start_date__lte=timezone.now()
+    )
+    for document in documents:
+        document.status = 'Aportaciones'
+        document.save()
+
+    documents = Document.objects.filter(
+        status='Aportaciones',
+        suggestion_end_date__lte=timezone.now()
+    )
+    for document in documents:
+        document.status = 'Votaciones'
+        document.save()
+
+    documents = Document.objects.filter(
+        status='Votaciones',
+        voting_end_date__lte=timezone.now()
+    )
+    for document in documents:
+        document.status = 'En revisión'
+        document.save()
+
+# Programa la tarea para que se ejecute diariamente
+schedule(
+    'documents.tasks.update_document_status',
+    schedule_type=Schedule.DAILY
+)

--- a/cocemfe_sevilla/requirements.txt
+++ b/cocemfe_sevilla/requirements.txt
@@ -5,4 +5,5 @@ coverage==6.5.0
 requests==2.31.0
 channels==4.1.0
 daphne==4.1.2
-django-cors-headers==4.3.1
+django-cors-headers==4
+django-q==1.3.9


### PR DESCRIPTION
Con esto los estados se actualizan automáticamente.
Habría que ejecutar (además del runserver) el comando 'python manage qcluster' para que el proceso se ejecute en segundo plano.
Hay que ejecutar el makemigrations y migrate para que funcione. Si os da error, hay que comentar las lineas 8 y 9 del archivo apps.py del modulo de documents, despues hacer las migraciones y descomentarlas.

close #352